### PR TITLE
Cinnamon Support Study

### DIFF
--- a/hotkeys.js
+++ b/hotkeys.js
@@ -1,11 +1,26 @@
 // Library imports
 const Main = imports.ui.main;
 const Meta = imports.gi.Meta;
-const Shell = imports.gi.Shell;
+try {
+    const Shell = imports.gi.Shell;
+} catch (e) {
+    const Shell = imports.gi.Cinnamon;
+}
+
 
 // Extension imports
-const Extension = imports.misc.extensionUtils.getCurrentExtension();
-const Settings = Extension.imports.settings;
+try {
+    const ExtensionUtils = imports.misc.extensionUtils;
+} catch (e) {
+}
+
+if (typeof ExtensionUtils !== 'undefined') {
+    const Extension = ExtensionUtils.getCurrentExtension();
+    const Settings = Extension.imports.settings;
+} else {
+    const Extension = imports.ui.extensionSystem.extensions['gTile@vibou'];
+    const Settings = imports.ui.settings;
+}
 
 // Copy from extention.js
 const SETTINGS_DEBUG = 'debug';

--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,13 @@
     "3.16",
     "3.14"
   ],
+  "cinnamon-version": [
+    "1.8",
+    "2.0",
+    "2.2",
+    "2.4",
+    "3.6"
+  ],
   "uuid": "gTile@vibou",
   "name": "gTile",
   "description": "Tile windows on a grid.",

--- a/settings-schema.json
+++ b/settings-schema.json
@@ -1,0 +1,141 @@
+{
+ "headerKeys" : {
+	"type" : "header",
+	"description" : "Hotkeys:"
+ },
+
+ "hotkey": {
+    "type" : "keybinding",
+    "default" : "<Super>space",
+    "description" : "Global Hotkey for gTile"
+ },
+ "seperator1" : {
+	"type" : "separator"
+ },
+ "header1" : {
+	"type" : "header",
+	"description" : "Button 1:"
+ },
+ "gridbutton1x": {
+    "type" : "spinbutton",
+	"indent" : "true",
+    "default" : 2,
+    "min" : 1,
+    "max" : 20,
+    "units" : "x ",
+	"step" : 1,
+    "description" : "Cols "
+ },
+ "gridbutton1y": {
+    "type" : "spinbutton",
+	"indent" : "true",
+    "default" : 2,
+    "min" : 1,
+    "max" : 20,
+    "units" : "y ",
+	"step" : 1,
+    "description" : "Rows"
+ },
+ "seperator2" : {
+	"type" : "separator"
+ },
+ "header2" : {
+	"type" : "header",
+	"description" : "Button 2:"
+ },
+ "gridbutton2x": {
+    "type" : "spinbutton",
+	"indent" : "true",
+    "default" : 3,
+    "min" : 1,
+    "max" : 20,
+    "units" : "x ",
+	"step" : 1,
+    "description" : "Cols "
+ },
+ "gridbutton2y": {
+    "type" : "spinbutton",
+	"indent" : "true",
+    "default" : 2,
+    "min" : 1,
+    "max" : 20,
+    "units" : "y ",
+	"step" : 1,
+    "description" : "Rows"
+ },
+ "seperator3" : {
+	"type" : "separator"
+ },
+ "header3" : {
+	"type" : "header",
+	"description" : "Button 3:"
+ },
+ "gridbutton3x": {
+    "type" : "spinbutton",
+	"indent" : "true",
+    "default" : 4,
+    "min" : 1,
+    "max" : 20,
+    "units" : "x ",
+	"step" : 1,
+    "description" : "Cols "
+ },
+ "gridbutton3y": {
+    "type" : "spinbutton",
+	"indent" : "true",
+    "default" : 4,
+    "min" : 1,
+    "max" : 20,
+    "units" : "y ",
+	"step" : 1,
+    "description" : "Rows"
+ },
+ "seperator4" : {
+	"type" : "separator"
+ },
+ "header4" : {
+	"type" : "header",
+	"description" : "Button 4:"
+ },
+ "gridbutton4x": {
+    "type" : "spinbutton",
+	"indent" : "true",
+    "default" : 6,
+    "min" : 1,
+    "max" : 20,
+    "units" : "x ",
+	"step" : 1,
+    "description" : "Cols "
+ },
+ "gridbutton4y": {
+    "type" : "spinbutton",
+	"indent" : "true",
+    "default" : 6,
+    "min" : 1,
+    "max" : 20,
+    "units" : "y ",
+	"step" : 1,
+    "description" : "Rows"
+ },
+ "seperator5" : {
+	"type" : "separator"
+ },
+ "autoclose" : {
+	"type" : "checkbox",
+	"default" : "true",
+	"description" : "Auto-Close"
+ },
+ "animation" : {
+	"type" : "checkbox",
+	"default" : "true",
+	"description" : "Animation"
+ },
+ "lastGridCols" : {
+	"type" : "generic",
+	"default" : 4
+ },
+ "lastGridRows" : {
+	"type" : "generic",
+	"default" : 4
+ }
+}


### PR DESCRIPTION
Big Hurdles:

1. Settings management
- The two API's have diverged significantly in the time since Cinnamon split from GNOME 3.
- We would need to make or find a module to abstract the settings management away.
2. Key bindings
- There seem to also be substantial differences in that department that would need managing
3. PanelMenu dependency
- Cinnamon got rid of panelMenu.js, so we would have to either selectively depend on panelMenu.js, or find a method to do the same functionality that works in both.

I think to some degree the settings issue will come back around sooner or later just due to API changes within GNOME (although it seems to have quieted down on the breaking things), but this would probably lead to a large scale restructuring as things are moved out to modules that are loaded in depending on the DE we're running in.  That could be a very good thing, but it seems like something that isn't started lightly.

see #20 
