### PR TITLE
Fix gTile for GNOME >= 3.30

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -31,7 +31,7 @@ const Workspace = imports.ui.workspace;
 // Extension imports
 const Extension = imports.misc.extensionUtils.getCurrentExtension();
 const Settings = Extension.imports.settings;
-const hotkeys = Extension.imports.hotkeys;
+const Hotkeys = Extension.imports.hotkeys;
 
 // Globals
 const SETTINGS_GRID_SIZES = 'grid-sizes';
@@ -184,8 +184,8 @@ const GTileStatusButton = new Lang.Class({
 function parseTuple(format, delimiter) {
     // parsing grid size in format XdelimY, like 6x4 or 1:2
     let gssk = format.split(delimiter);
-    if(gssk.length != 2 
-        || isNaN(gssk[0]) || gssk[0] < 0 || gssk[0] > 40 
+    if(gssk.length != 2
+        || isNaN(gssk[0]) || gssk[0] < 0 || gssk[0] > 40
         || isNaN(gssk[1]) || gssk[1] < 0 || gssk[1] > 40) {
         log("Bad format " + format + ", delimiter " + delimiter);
         return {X: Number(-1), Y: Number(-1)};
@@ -199,7 +199,7 @@ function initGridSizes(grid_sizes) {
         new GridSettingsButton('8x6',8,6),
         new GridSettingsButton('6x4',6,4),
         new GridSettingsButton('4x4',4,4),
-    ];  
+    ];
     let grid_sizes_orig = true;
     let gss = grid_sizes.split(",");
     for (var key in gss) {
@@ -221,17 +221,17 @@ function getBoolSetting (settings_string) {
 	log("Undefined settings " + settings_string);
         gridSettings[settings_string] = false;
     } else {
-        //log(settings_string + " set to " + gridSettings[settings_string]);  
+        //log(settings_string + " set to " + gridSettings[settings_string]);
     }
 }
 
 function getIntSetting (settings_string) {
     let iss = settings.get_int(settings_string);
-    if(iss === undefined) { 
-        log("Undefined settings " + settings_string);  
+    if(iss === undefined) {
+        log("Undefined settings " + settings_string);
         return 0;
     } else {
-        //log(settings_string + " set to " + iss);  
+        //log(settings_string + " set to " + iss);
         return iss;
     }
 }
@@ -249,16 +249,16 @@ function initSettings() {
 
     gridSettings[SETTINGS_WINDOW_MARGIN] = getIntSetting(SETTINGS_WINDOW_MARGIN);
 
-    gridSettings[SETTINGS_INSETS_PRIMARY] = 
-        { top:    getIntSetting(SETTINGS_INSETS_PRIMARY_TOP), 
-        bottom: getIntSetting(SETTINGS_INSETS_PRIMARY_BOTTOM), 
-        left:   getIntSetting(SETTINGS_INSETS_PRIMARY_LEFT), 
+    gridSettings[SETTINGS_INSETS_PRIMARY] =
+        { top:    getIntSetting(SETTINGS_INSETS_PRIMARY_TOP),
+        bottom: getIntSetting(SETTINGS_INSETS_PRIMARY_BOTTOM),
+        left:   getIntSetting(SETTINGS_INSETS_PRIMARY_LEFT),
         right:  getIntSetting(SETTINGS_INSETS_PRIMARY_RIGHT) }; // Insets on primary monitor
-    gridSettings[SETTINGS_INSETS_SECONDARY] = 
-        { top:    getIntSetting(SETTINGS_INSETS_SECONDARY_TOP), 
-        bottom: getIntSetting(SETTINGS_INSETS_SECONDARY_BOTTOM), 
-        left:   getIntSetting(SETTINGS_INSETS_SECONDARY_LEFT), 
-        right:  getIntSetting(SETTINGS_INSETS_SECONDARY_RIGHT) }; 
+    gridSettings[SETTINGS_INSETS_SECONDARY] =
+        { top:    getIntSetting(SETTINGS_INSETS_SECONDARY_TOP),
+        bottom: getIntSetting(SETTINGS_INSETS_SECONDARY_BOTTOM),
+        left:   getIntSetting(SETTINGS_INSETS_SECONDARY_LEFT),
+        right:  getIntSetting(SETTINGS_INSETS_SECONDARY_RIGHT) };
 
     // initialize these from settings, the first set of sizes
     if(nbCols == 0 || nbRows == 0) {
@@ -300,19 +300,19 @@ function enable() {
 		Main.panel.addToStatusArea("GTileStatusButton", launcher);
 	}
 
-    hotkeys.bind(key_bindings);
+    Hotkeys.bind(key_bindings);
     if(gridSettings[SETTINGS_GLOBAL_PRESETS]) {
-        hotkeys.bind(key_bindings_presets);
+        Hotkeys.bind(key_bindings_presets);
     }
     log("Extention Enabled!");
 }
 
 function disable() {
     log("Extension start disabling");
-    hotkeys.unbind(key_bindings);
-    hotkeys.unbind(key_bindings_presets);
+    Hotkeys.unbind(key_bindings);
+    Hotkeys.unbind(key_bindings_presets);
     if(keyControlBound) {
-        hotkeys.unbind(key_bindings_tiling);
+        Hotkeys.unbind(key_bindings_tiling);
         keyControlBound = false;
     }
     destroyGrids();
@@ -546,7 +546,7 @@ function _onFocus() {
 
     if (window && status) {
         log("_onFocus " + window.get_title());
-        focusMetaWindow = window;	
+        focusMetaWindow = window;
 
         let app = tracker.get_window_app(focusMetaWindow);
         let title = focusMetaWindow.get_title();
@@ -634,7 +634,7 @@ function hideTiling() {
     resetFocusMetaWindow();
 
     launcher.deactivate();
-    status = false;    
+    status = false;
     unbindKeyControls();
 }
 
@@ -721,29 +721,29 @@ function getWorkArea(monitor, monitor_idx) {
 
 function bindKeyControls() {
     if(!keyControlBound) {
-        hotkeys.bind(key_bindings_tiling);
+        Hotkeys.bind(key_bindings_tiling);
         //log("Connect notify:focus-window");
         if(focusConnect) {
             global.display.disconnect(focusConnect);
         }
         focusConnect = global.display.connect('notify::focus-window', Lang.bind(this, _onFocus));
         if(!gridSettings[SETTINGS_GLOBAL_PRESETS]) {
-            hotkeys.bind(key_bindings_presets);
-        }	
+            Hotkeys.bind(key_bindings_presets);
+        }
         keyControlBound = true;
     }
 }
 
 function unbindKeyControls() {
     if(keyControlBound) {
-        hotkeys.unbind(key_bindings_tiling);
+        Hotkeys.unbind(key_bindings_tiling);
         if(focusConnect) {
             log("Disconnect notify:focus-window");
             global.display.disconnect(focusConnect);
             focusConnect = false;
         }
         if(!gridSettings[SETTINGS_GLOBAL_PRESETS]) {
-            hotkeys.unbind(key_bindings_presets);
+            Hotkeys.unbind(key_bindings_presets);
         }
         keyControlBound = false;
     }
@@ -790,7 +790,7 @@ function keyChangeTiling() {
     setInitialSelection();
 }
 
-function setInitialSelection() {  
+function setInitialSelection() {
     if (!focusMetaWindow) {
         return;
     }
@@ -807,9 +807,9 @@ function setInitialSelection() {
     let delegate = grid.elementsDelegate;
 
     log("Set initial selection");
-    log("Focus window position x " + wx + " y " + wy + " width " + wwidth + " height " + wheight); 
-    log("Focus monitor position x " + monitor.x + " y " + monitor.y + " width " + monitor.width + " height " + monitor.height); 
-    log("Workarea position x " + workArea.x + " y " + workArea.y + " width " + workArea.width + " height " + workArea.height); 
+    log("Focus window position x " + wx + " y " + wy + " width " + wwidth + " height " + wheight);
+    log("Focus monitor position x " + monitor.x + " y " + monitor.y + " width " + monitor.width + " height " + monitor.height);
+    log("Workarea position x " + workArea.x + " y " + workArea.y + " width " + workArea.width + " height " + workArea.height);
     let wax = Math.max(wx - workArea.x, 0);
     let way = Math.max(wy - workArea.y, 0);
     let grid_element_width = Math.floor(workArea.width / nbCols);
@@ -824,22 +824,22 @@ function setInitialSelection() {
     let rdy = Math.min(Math.floor((way + wheight - 1) / grid_element_height), grid.rows - 1);
     log("wy + wheight " + (wy + wheight - workArea.y - 1) + " el_height " + grid_element_height + " max " + (nbRows - 1) + " res " + rdy);
     log("Initial tile selection is " + lux + ":" + luy + " - " + rdx + ":" + rdy);
-    
+
 	grid.forceGridElementDelegate(lux, luy, rdx, rdy);
-	
-    grid.elements[luy] [lux]._onButtonPress();     
-    grid.elements[rdy] [rdx]._onHoverChanged();    
+
+    grid.elements[luy] [lux]._onButtonPress();
+    grid.elements[rdy] [rdx]._onHoverChanged();
 
     let cX = delegate.currentElement.coordx;
     let cY = delegate.currentElement.coordy;
     let fX = delegate.first.coordx;
     let fY = delegate.first.coordy;
 
-    log("After initial selection first fX " + fX + " fY " + fY + " current cX " + cX + " cY " + cY);      
+    log("After initial selection first fX " + fX + " fY " + fY + " current cX " + cX + " cY " + cY);
 }
 
 function keyMoveResizeEvent(type, key) {
-    log("Got key event " + type + " " + key);  
+    log("Got key event " + type + " " + key);
     if (!focusMetaWindow) {
         return;
     }
@@ -848,7 +848,7 @@ function keyMoveResizeEvent(type, key) {
     let mkey = getMonitorKey(monitor);
     let grid = grids[mkey];
     let delegate = grid.elementsDelegate;
-    
+
     if(!delegate.currentElement) {
         log("Key event while no mouse activation - set current and second element");
         setInitialSelection();
@@ -865,68 +865,68 @@ function keyMoveResizeEvent(type, key) {
     let cY = delegate.currentElement.coordy;
     let fX = delegate.first.coordx;
     let fY = delegate.first.coordy;
-    
+
     log("Before move/resize first fX " + fX + " fY " + fY + " current cX " + cX + " cY " + cY);
     log("Grid cols " + nbCols + " rows " + nbRows);
-    if(type == 'move') {	 
+    if(type == 'move') {
         switch(key) {
             case 'right':
             if(fX < nbCols - 1 && cX < nbCols - 1) {
                 delegate.first = grid.elements [fY] [fX + 1];
-                grid.elements[cY] [cX + 1]._onHoverChanged(); 
+                grid.elements[cY] [cX + 1]._onHoverChanged();
             }
             break;
             case 'left':
             if(fX > 0 && cX > 0) {
                 delegate.first = grid.elements [fY] [fX - 1];
-                grid.elements[cY] [cX - 1]._onHoverChanged(); 
+                grid.elements[cY] [cX - 1]._onHoverChanged();
             }
             break;
             case 'up':
             if(fY > 0 && cY > 0) {
                 delegate.first = grid.elements [fY - 1] [fX];
-                grid.elements[cY - 1] [cX]._onHoverChanged(); 
+                grid.elements[cY - 1] [cX]._onHoverChanged();
             }
             break;
             case 'down':
             if(fY < nbRows - 1 && cY < nbRows - 1) {
                 delegate.first = grid.elements [fY + 1] [fX];
-                grid.elements[cY + 1] [cX]._onHoverChanged(); 
+                grid.elements[cY + 1] [cX]._onHoverChanged();
             }
             break;
-        }      
+        }
         } else {
         switch(key) {
             case 'right':
             if(cX < nbCols - 1) {
-                grid.elements[cY] [cX + 1]._onHoverChanged(); 
+                grid.elements[cY] [cX + 1]._onHoverChanged();
             }
             break;
             case 'left':
             if(cX > 0) {
-                grid.elements[cY] [cX - 1]._onHoverChanged(); 
+                grid.elements[cY] [cX - 1]._onHoverChanged();
             }
             break;
             case 'up':
             if(cY > 0 ) {
-                grid.elements[cY - 1] [cX]._onHoverChanged(); 
+                grid.elements[cY - 1] [cX]._onHoverChanged();
             }
             break;
             case 'down':
             if(cY < nbRows - 1) {
-                grid.elements[cY + 1] [cX]._onHoverChanged(); 
+                grid.elements[cY + 1] [cX]._onHoverChanged();
             }
             break;
         }
     }
-    
+
     cX = delegate.currentElement.coordx;
     cY = delegate.currentElement.coordy;
     fX = delegate.first.coordx;
     fY = delegate.first.coordy;
-    
+
     log("After move/resize first fX " + fX + " fY " + fY + " current cX " + cX + " cY " + cY);
-    
+
 }
 
 function presetResize(preset) {
@@ -942,9 +942,9 @@ function presetResize(preset) {
     }
 
     reset_window(window);
-    
+
     let preset_string = settings.get_string("resize" + preset);
-    log("Preset resize " + preset + "  is " + preset_string);  
+    log("Preset resize " + preset + "  is " + preset_string);
     let ps = preset_string.split(" ");
     if(ps.length != 3) {
         log("Bad preset " + preset + " settings " + preset_string);
@@ -953,19 +953,19 @@ function presetResize(preset) {
     let grid_format = parseTuple(ps[0], "x");
     let luc = parseTuple(ps[1], ":");
     let rdc = parseTuple(ps[2], ":");
-    log("Parsed " + grid_format.X + "x" + grid_format.Y + " " 
+    log("Parsed " + grid_format.X + "x" + grid_format.Y + " "
         + luc.X + ":" + luc.Y + " " + rdc.X + ":" + rdc.Y);
-    if  (  grid_format.X < 1 || luc.X < 0 || rdc.X < 0 
-        || grid_format.Y < 1 || luc.Y < 0 || rdc.Y < 0 
-        || grid_format.X <= luc.X || grid_format.X <= rdc.X 
-        || grid_format.Y <= luc.Y || grid_format.Y <= rdc.Y 
+    if  (  grid_format.X < 1 || luc.X < 0 || rdc.X < 0
+        || grid_format.Y < 1 || luc.Y < 0 || rdc.Y < 0
+        || grid_format.X <= luc.X || grid_format.X <= rdc.X
+        || grid_format.Y <= luc.Y || grid_format.Y <= rdc.Y
         || luc.X > rdc.X || luc.Y > rdc.Y) {
         log("Bad preset " + preset + " settings " + preset_string);
-        return;      
+        return;
     }
     log("Parsed preset " + preset + " " + grid_format.X + "x" + grid_format.Y +
         " " + luc.X + ":" + luc.Y + " " + rdc.X + ":" + rdc.Y);
-    
+
     let mind = window.get_monitor();
     let work_area = getWorkAreaByMonitorIdx(mind);
     let grid_element_width = Math.floor(work_area.width / grid_format.X);
@@ -974,8 +974,8 @@ function presetResize(preset) {
     let wy = work_area.y + luc.Y * grid_element_height + gridSettings[SETTINGS_WINDOW_MARGIN];
     let ww = (rdc.X + 1 - luc.X) * grid_element_width - 2 * gridSettings[SETTINGS_WINDOW_MARGIN];
     let wh = (rdc.Y + 1 - luc.Y) * grid_element_height- 2 * gridSettings[SETTINGS_WINDOW_MARGIN];
-    
-    log("Resize preset " + preset + " resizing to wx " + wx + " wy " + wy + " ww " + ww + " wh " + wh);    
+
+    log("Resize preset " + preset + " resizing to wx " + wx + " wy " + wy + " ww " + ww + " wh " + wh);
     window.move_resize_frame(true, wx, wy, ww, wh);
 }
 
@@ -1175,7 +1175,7 @@ function AutoTileMain() {
 			winHeight
 		);
 		countWin++;
-	}	
+	}
 	log("AutoTileMain done");
 }
 
@@ -1219,7 +1219,7 @@ function AutoTileNCols(cols) {
 	let monitor = monitors[mind];
 	let workArea = getWorkAreaByMonitor(monitor);
 	let windows = getNotFocusedWindowsOfMonitor(monitor);
-	
+
 	let nbWindowOnEachSide = Math.ceil((windows.length + 1) / cols);
 	let winHeight = workArea.height/nbWindowOnEachSide;
 
@@ -1250,7 +1250,7 @@ function AutoTileNCols(cols) {
 		);
 		countWin++;
 	}
-	
+
 	log("AutoTileNCols done");
 }
 
@@ -1393,7 +1393,7 @@ Grid.prototype = {
         this.rows = rows;
         this.title = title;
         this.cols = cols;
-	
+
         this.isEntered = false;
 
         let nbTotalSettings = 4;
@@ -1457,7 +1457,7 @@ Grid.prototype = {
 		//log("Grid forceGridElementDelegate " + x + ":" + y + " - " + w + ":" + h);
 		this.elementsDelegate.forceArea(this.elements[y][x], this.elements[h][w]);
 	},
-	
+
     refresh: function() {
 		//log("Grid refresh")
 		//this.elementsDelegate._logActiveActors("Grid refresh active actors");
@@ -1675,10 +1675,10 @@ GridElementDelegate.prototype = {
             if(this.activatedActors[act].active) {
 				activeActorsString = activeActorsString +"A";
 			} else {
-				activeActorsString = activeActorsString +"U";				
+				activeActorsString = activeActorsString +"U";
 			}
         }
-        log(prefixString + " " + activeActorsString);		
+        log(prefixString + " " + activeActorsString);
 	},
 	*/
     _resetGrid: function() {
@@ -1750,7 +1750,7 @@ GridElementDelegate.prototype = {
 		area.width = areaWidth;
 		area.height = areaHeight;
 		area.x = areaX;
-		area.y = areaY;		
+		area.y = areaY;
 	},
 
     _displayArea: function(fromGridElement, toGridElement) {
@@ -1779,7 +1779,7 @@ GridElementDelegate.prototype = {
         }
     },
 
-    _hideArea: function() { 
+    _hideArea: function() {
         area.remove_style_pseudo_class('activate');
     },
 
@@ -1797,8 +1797,8 @@ GridElementDelegate.prototype = {
 
             this.currentElement = gridElement;
 			//log("GridElementDelegate _onHoverChange currentElement new activating" + this.currentElement.id);
-            this.currentElement._activate();	    
-            this._displayArea(gridElement,gridElement);	    
+            this.currentElement._activate();
+            this._displayArea(gridElement,gridElement);
         }
     },
 
@@ -1884,7 +1884,7 @@ GridElement.prototype = {
 	_disconnect: function() {
 		this.actor.disconnect(this.hoverConnect);
 	},
-	
+
     _destroy: function() {
         this.monitor = null;
         this.coordx = null;

--- a/extension.js
+++ b/extension.js
@@ -27,6 +27,8 @@ const Clutter = imports.gi.Clutter;
 const Signals = imports.signals;
 const Tweener = imports.ui.tweener;
 const Workspace = imports.ui.workspace;
+// Getter for accesing "get_active_workspace" on GNOME <=2.28 and >= 2.30
+const WorkspaceManager = global.screen || global.workspace_manager;
 
 // Extension imports
 const Extension = imports.misc.extensionUtils.getCurrentExtension();
@@ -519,7 +521,7 @@ function getNotFocusedWindowsOfMonitor(monitor) {
 
         return !contains(excludedApplications, appName)
             && w.meta_window.get_window_type() == Meta.WindowType.NORMAL
-            && w.meta_window.get_workspace() == global.screen.get_active_workspace()
+            && w.meta_window.get_workspace() == WorkspaceManager.get_active_workspace()
             && w.meta_window.showing_on_its_workspace()
             && monitors[w.meta_window.get_monitor()] == monitor
             && focusMetaWindow != w.meta_window;
@@ -531,7 +533,7 @@ function getNotFocusedWindowsOfMonitor(monitor) {
 function getWindowsOfMonitor(monitor) {
     let windows = global.get_window_actors().filter(function(w) {
         return w.meta_window.get_window_type() != Meta.WindowType.DESKTOP
-            && w.meta_window.get_workspace() == global.screen.get_active_workspace()
+            && w.meta_window.get_workspace() == WorkspaceManager.get_active_workspace()
             && w.meta_window.showing_on_its_workspace()
             && monitors[w.meta_window.get_monitor()] == monitor;
     });
@@ -674,7 +676,7 @@ function getFocusApp() {
         return false;
     }
 
-    let windows = global.screen.get_active_workspace().list_windows();
+    let windows = WorkspaceManager.get_active_workspace().list_windows();
     let focusedWindow = false;
     for (let i = 0; i < windows.length; ++i) {
         let metaWindow = windows[i];
@@ -707,7 +709,7 @@ function getWorkAreaByMonitorIdx(monitor_idx) {
 }
 
 function getWorkArea(monitor, monitor_idx) {
-    let wkspace = global.screen.get_active_workspace();
+    let wkspace = WorkspaceManager.get_active_workspace();
     let work_area = wkspace.get_work_area_for_monitor(monitor_idx);
     //log("getWorkArea for monitor " + monitor_idx + " - work_area " + work_area.x + ":" + work_area.y + ":" + work_area.width + ":" + work_area.height );
     let insets = (isPrimaryMonitor(monitor)) ? gridSettings[SETTINGS_INSETS_PRIMARY] : gridSettings[SETTINGS_INSETS_SECONDARY];


### PR DESCRIPTION
As described at https://github.com/micheleg/dash-to-dock/pull/770, all workspace related features that used to be on **global.screen** have moved to **global.workspace_manager**.

The fix enables gTile to work on all GNOME <= 3.30.

NOTE: That the diff shows a bunch of changes but most of it was white-space removed by my linter.