### PR TITLE
Adds 3.30 to supported gnome-shell versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -11,7 +11,8 @@
     "3.24", 
     "3.26",
     "3.27",
-    "3.28"
+    "3.28",
+    "3.30"
   ], 
   "url": "https://github.com/gTile", 
   "uuid": "gTile@vibou", 


### PR DESCRIPTION
I figured this was missing when looking at #51 