### PR TITLE
Enhance description regarding preset definitions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In the *Help* tab you will find help and usage hints.
 	* Written as a comma-separated list of grid sizes like `8x7,3x2,4x6,4x7` (no spaces)
 * Resize presets:
 	* Are defined in the preferences window (*Reset presets* tab) 
-	* Format: grid size, top left corner, bottom right corner
+	* Format: grid size, top left corner tile, bottom right corner tile
 	* Format examples: "2x2 0:1 0:1" or "6x4 0:2 3:3"
 	* Grids setup here size can be of any size, not necessarily what you have set up in grid sizes settings
 

--- a/extension.js
+++ b/extension.js
@@ -934,8 +934,8 @@ function keyMoveResizeEvent(type, key) {
 function presetResize(preset) {
     // Expected preset format is XxY x1:y1 x2:y2
     // XxY is grid size like 6x8
-    // x1:y1 is left upper corner coordinates in grid tiles, starting from 0
-    // x2:y2 is right down corner coordinates in grid tiles
+    // x1:y1 is left upper corner tile coordinates in grid tiles, starting from 0
+    // x2:y2 is right down corner tile coordinates in grid tiles
 
     let window = getFocusApp();
     if (!window) {

--- a/prefs.js
+++ b/prefs.js
@@ -78,7 +78,7 @@ const pretty_names = {
     'preset-resize-28'  : 'Preset resize 28',
     'preset-resize-29'  : 'Preset resize 29',
     'preset-resize-30'  : 'Preset resize 30'
-} 
+}
 
 function init() {
 
@@ -165,7 +165,7 @@ function accel_tab(notebook) {
     let ks_window = new Gtk.ScrolledWindow({'vexpand': true});
         ks_window.add(ks_grid);
     let ks_label = new Gtk.Label({ label: "Accelerators", use_markup: false, halign: Gtk.Align.START })	
-    notebook.append_page(ks_window, ks_label);	  
+    notebook.append_page(ks_window, ks_label);
 }
 
 function basics_tab(notebook) {
@@ -202,8 +202,8 @@ function presets_tab(notebook) {
                                   row_spacing: 6,
                                   column_spacing: 6 });
 
-    let text = "Resize presets (grid size and 2 corners, 2x2 0:1 0:1 is left bottom quarter)";
-    pr_grid.add(new Gtk.Label({ label: text, use_markup: false, halign: Gtk.Align.START }));	
+    let text = "Resize presets (grid size and 2 corner tiles, e.g. '2x2 0:1 0:1' is left bottom quarter)";
+    pr_grid.add(new Gtk.Label({ label: text, use_markup: false, halign: Gtk.Align.START }));
 
     for (var ind = 1; ind <= 30; ind++) {
         add_text ("Preset resize " + ind, SETTINGS_PRESET_RESIZE + ind, pr_grid, settings, 20);
@@ -281,7 +281,7 @@ function buildPrefsWidget() {
 function add_check(check_label, SETTINGS, grid, settings) {
     let check = new Gtk.CheckButton({ label: check_label, margin_top: 6 });
     settings.bind(SETTINGS, check, 'active', Gio.SettingsBindFlags.DEFAULT);
-    grid.add(check);  
+    grid.add(check);
 }
 
 function add_int(int_label, SETTINGS, grid, settings, minv, maxv, incre, page) {


### PR DESCRIPTION
It took some time until I figured out how the presets are defined. I understood the hint "Resize presets (grid size and 2 corners, 2x2 0:1 0:1 is left bottom quarter)" as a rectangle that spans on a grid of coordinates. But that's not how it works. It spans from one tile to another. A colleague fell to the same assumption :-).

I therefore tried to clarify this a bit.