### PR TITLE
Add feature to disable accelerators (fixes #38)

### DIFF
--- a/prefs.js
+++ b/prefs.js
@@ -142,7 +142,6 @@ function accel_tab(notebook) {
         }
 
         let name = model.get_value(iter, 0);
-        global.log("Clearing value for " + name);
         model.set(iter, [3], [0]);
         settings.set_strv(name, ['']);
     });

--- a/prefs.js
+++ b/prefs.js
@@ -134,6 +134,19 @@ function accel_tab(notebook) {
         'accel-mode': Gtk.CellRendererAccelMode.GTK
     });
 
+    cellrend.connect('accel-cleared', function(rend, str_iter) {
+        let [success, iter] = model.get_iter_from_string(str_iter);
+
+        if (!success) {
+            throw new Error("Something be broken, yo.");
+        }
+
+        let name = model.get_value(iter, 0);
+        global.log("Clearing value for " + name);
+        model.set(iter, [3], [0]);
+        settings.set_strv(name, ['']);
+    });
+
     cellrend.connect('accel-edited', function(rend, str_iter, key, mods) {
         let value = Gtk.accelerator_name(key, mods);
 


### PR DESCRIPTION
Attach new signal "accel-cleared" and use it to disable the associated
accelerator. It uses the standard Gnome UX: select accelerator, click/enter, then backspace to disable.

Demo:

![Peek 2019-04-03 15-00](https://user-images.githubusercontent.com/320904/55505523-4438e680-5621-11e9-839e-db084d966071.gif)
