### PR TITLE
Fix bad imports of logging.js; migrate more files to Typescript.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,13 +35,11 @@ filegroup(
     name = "dist_files",
     srcs = [
         "extension.js",
-        "hotkeys.js",
         "metadata.json",
         "prefs.js",
         "schemas/gschemas.compiled",
         "schemas/org.gnome.shell.extensions.gtile.gschema.xml",
         "settings.js",
-        "snaptoneighbors.js",
         "stylesheet.css",
         "LICENSE"
     ] + glob([
@@ -70,7 +68,18 @@ ts_library(
     tsconfig = "//:tsconfig-app.json",
     deps = [
         ":logging_lib",
+        ":hotkeys_lib",
         ":shellversion_lib",
+        ":snaptoneighbors_lib",
+    ],
+)
+
+ts_library(
+    name = "hotkeys_lib",
+    srcs = ["hotkeys.ts"],
+    tsconfig = "//:tsconfig-app.json",
+    deps = [
+        ":logging_lib",
     ],
 )
 
@@ -86,6 +95,15 @@ ts_library(
 ts_library(
     name = "shellversion_lib",
     srcs = ["shellversion.ts"],
+    tsconfig = "//:tsconfig-app.json",
+    deps = [
+        ":logging_lib",
+    ],
+)
+
+ts_library(
+    name = "snaptoneighbors_lib",
+    srcs = ["snaptoneighbors.ts"],
     tsconfig = "//:tsconfig-app.json",
     deps = [
         ":logging_lib",

--- a/app.ts
+++ b/app.ts
@@ -4,6 +4,8 @@ declare var global:any;
 
 import {log, setLoggingEnabled} from './logging';
 import {ShellVersion} from './shellversion';
+import {bind as bindHotkeys, unbind as unbindHotkeys, Bindings} from './hotkeys';
+import { snapToNeighbors } from './snaptoneighbors';
 
 /*****************************************************************
 
@@ -40,8 +42,6 @@ const WorkspaceManager = global.screen || global.workspace_manager;
 // Extension imports
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Settings = Me.imports.settings;
-const Hotkeys = Me.imports.hotkeys;
-const SnapToNeighbors = Me.imports.snaptoneighbors;
 
 interface WorkArea {
     x: number;
@@ -110,12 +110,12 @@ let excludedApplications = new Array(
     "Unknown"
 );
 
-const key_bindings = {
+const keyBindings: Bindings = {
     'show-toggle-tiling': function() { toggleTiling(); },
     'show-toggle-tiling-alt': function() { toggleTiling(); }
 };
 
-const key_bindings_tiling = {
+const key_bindings_tiling: Bindings = {
     'move-left'       : function() { keyMoveResizeEvent('move'  , 'left' );},
     'move-right'      : function() { keyMoveResizeEvent('move'  , 'right');},
     'move-up'         : function() { keyMoveResizeEvent('move'  , 'up'   );},
@@ -149,7 +149,7 @@ const key_bindings_tiling = {
     'snap-to-neighbors': function() { SnapToNeighborsBind();}
 }
 
-const key_bindings_presets = {
+const key_bindings_presets: Bindings = {
     'preset-resize-1' : function() { presetResize(1)  ;},
     'preset-resize-2' : function() { presetResize(2)  ;},
     'preset-resize-3' : function() { presetResize(3)  ;},
@@ -181,7 +181,7 @@ const key_bindings_presets = {
     'preset-resize-29': function() { presetResize(29) ;},
     'preset-resize-30': function() { presetResize(30) ;}
 }
-const key_binding_global_resizes = {
+const key_binding_global_resizes: Bindings = {
   'action-change-tiling':   function()  { keyChangeTiling(); },
   'action-contract-bottom': function() { keyMoveResizeEvent('contract' , 'bottom', true );},
   'action-contract-left':   function() { keyMoveResizeEvent('contract' , 'left'  , true );},
@@ -382,12 +382,12 @@ export function enable() {
         Main.panel.addToStatusArea("GTileStatusButton", launcher);
     }
 
-    Hotkeys.bind(key_bindings);
+    bindHotkeys(keyBindings);
     if(gridSettings[SETTINGS_GLOBAL_PRESETS]) {
-        Hotkeys.bind(key_bindings_presets);
+        bindHotkeys(key_bindings_presets);
     }
     if(gridSettings[SETTINGS_MOVERESIZE_ENABLED]){
-        Hotkeys.bind(key_binding_global_resizes);
+        bindHotkeys(key_binding_global_resizes);
     }
     enabled = true;
     log("Extention Enabled!");
@@ -396,11 +396,11 @@ export function enable() {
 export function disable() {
     log("Extension start disabling");
     enabled = false;
-    Hotkeys.unbind(key_bindings);
-    Hotkeys.unbind(key_bindings_presets);
-    Hotkeys.unbind(key_binding_global_resizes);
+    unbindHotkeys(keyBindings);
+    unbindHotkeys(key_bindings_presets);
+    unbindHotkeys(key_binding_global_resizes);
     if(keyControlBound) {
-        Hotkeys.unbind(key_bindings_tiling);
+        unbindHotkeys(key_bindings_tiling);
         keyControlBound = false;
     }
     destroyGrids();
@@ -861,13 +861,13 @@ function getWorkArea(monitor: Monitor, monitor_idx: number): WorkArea {
 
 function bindKeyControls() {
     if(!keyControlBound) {
-        Hotkeys.bind(key_bindings_tiling);
+        bindHotkeys(key_bindings_tiling);
         if(focusConnect) {
             global.display.disconnect(focusConnect);
         }
         focusConnect = global.display.connect('notify::focus-window', _onFocus);
         if(!gridSettings[SETTINGS_GLOBAL_PRESETS]) {
-            Hotkeys.bind(key_bindings_presets);
+            bindHotkeys(key_bindings_presets);
         }
         keyControlBound = true;
     }
@@ -875,17 +875,17 @@ function bindKeyControls() {
 
 function unbindKeyControls() {
     if(keyControlBound) {
-        Hotkeys.unbind(key_bindings_tiling);
+        unbindHotkeys(key_bindings_tiling);
         if(focusConnect) {
             log("Disconnect notify:focus-window");
             global.display.disconnect(focusConnect);
             focusConnect = false;
         }
         if(!gridSettings[SETTINGS_GLOBAL_PRESETS]) {
-            Hotkeys.unbind(key_bindings_presets);
+            unbindHotkeys(key_bindings_presets);
         }
         if(!gridSettings[SETTINGS_MOVERESIZE_ENABLED]){
-            Hotkeys.unbind(key_binding_global_resizes);
+            unbindHotkeys(key_binding_global_resizes);
         }
         keyControlBound = false;
     }
@@ -1555,7 +1555,7 @@ function SnapToNeighborsBind() {
         return;
     }
 
-    SnapToNeighbors.snapToNeighbors(window);
+    snapToNeighbors(window);
 }
 
 function GridSettingsButton(text,cols,rows) {

--- a/hotkeys.ts
+++ b/hotkeys.ts
@@ -1,4 +1,8 @@
-'use strict'
+import {log} from './logging';
+
+declare const imports: any;
+declare const global: any;
+
 // Library imports
 const Main = imports.ui.main;
 const Meta = imports.gi.Meta;
@@ -7,26 +11,26 @@ const Shell = imports.gi.Shell;
 // Extension imports
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Settings = Me.imports.settings;
-const Log = Me.imports.logging;
 
 // Globals
 const mySettings = Settings.get();
 
-function log(log_string) {
-    Log.log(log_string);
-}
+/**
+ * Bindings is a dictionary that maps a hotkey name to a function that handles
+ * the press of the key that is bound to that action.
+ */
+export type Bindings = {[name: string]: () => void};
 
-function bind(key_bindings) {
+export function bind(keyBindings: Bindings) {
     log("Binding keys");
-    for (var key in key_bindings) {
-        //log("Binding key: " + key);
+    for (var key in keyBindings) {
         if (Main.wm.addKeybinding && Shell.ActionMode) { // introduced in 3.16
             Main.wm.addKeybinding(
                 key,
                 mySettings,
                 Meta.KeyBindingFlags.NONE,
                 Shell.ActionMode.NORMAL,
-                key_bindings[key]
+                keyBindings[key]
             );
         }
         else if (Main.wm.addKeybinding && Shell.KeyBindingMode) { // introduced in 3.7.5
@@ -35,7 +39,7 @@ function bind(key_bindings) {
                 mySettings,
                 Meta.KeyBindingFlags.NONE,
                 Shell.KeyBindingMode.NORMAL | Shell.KeyBindingMode.MESSAGE_TRAY,
-                key_bindings[key]
+                keyBindings[key]
             );
         }
         else {
@@ -43,16 +47,15 @@ function bind(key_bindings) {
                 key,
                 mySettings,
                 Meta.KeyBindingFlags.NONE,
-                key_bindings[key]
+                keyBindings[key]
             );
         }
     }
 }
 
-function unbind(key_bindings) {
+export function unbind(keyBindings: Bindings) {
     log("Unbinding keys");
-    for (var key in key_bindings) {
-        //log("Unbinding key: " + key);
+    for (var key in keyBindings) {
         if (Main.wm.removeKeybinding) { // introduced in 3.7.2
             Main.wm.removeKeybinding(key);
         }

--- a/prefs.js
+++ b/prefs.js
@@ -9,7 +9,6 @@ const Lang = imports.lang;
 // Extension imports
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Settings = Me.imports.settings;
-const Log = Me.imports.logging;
 
 // Redefining globals from extension.js - do not know how to do it better :-(
 const SETTINGS_GRID_SIZES = 'grid-sizes';
@@ -181,8 +180,6 @@ function accel_tab(notebook) {
         let name = model.get_value(iter, 0);
 
         model.set(iter, [ 2, 3 ], [ mods, key ]);
-
-        Log.log("Changing value for " + name + ": " + value);
 
         settings.set_strv(name, [value]);
     });

--- a/snaptoneighbors.ts
+++ b/snaptoneighbors.ts
@@ -1,28 +1,19 @@
-'use strict'
 /* Edited by Sergey after 
 https://github.com/tpyl/gssnaptoneighbors
  by Timo Pylvanainen <tpyl@iki.fi>
  */
 
-const Gio = imports.gi.Gio;
-const Meta = imports.gi.Meta;
-const Shell = imports.gi.Shell;
-const St = imports.gi.St;
-const Tweener = imports.ui.tweener;
+import {log} from './logging';
 
-const Main = imports.ui.main;
+declare const imports: any;
+declare const global: any;
+
+const Meta = imports.gi.Meta;
 
 const WorkspaceManager = global.screen || global.workspace_manager;
 
-const Me = imports.misc.extensionUtils.getCurrentExtension();
-const Log = Me.imports.logging;
-
 const OVERLAP_TOLERANCE = 5;
 const SCAN_BOX_SIZE = 50;
-
-function log(log_string) {
-    Log.log(log_string);
-}
 
 /**
  * Return all windows on the currently active workspace
@@ -113,6 +104,35 @@ function expandVertically(y, left, right, miny, maxy, windows) {
 }
 
 /**
+ * Type definition based on
+ * https://gjs-docs.gnome.org/meta6~6_api/meta.window#method-get_layer and 
+ * https://developer.gnome.org/meta/stable/MetaWindow.html#meta-window-get-work-area-current-monitor.
+ */
+interface MetaWindow {
+    readonly maximized_horizontally: boolean;
+    readonly maximized_vertically: boolean;
+    get_title(): string;
+    unmaximize(flags: any): void;
+    get_work_area_current_monitor(): MetaRectangle;
+    get_frame_rect(): MetaRectangle;
+
+    /**
+     * https://gjs-docs.gnome.org/meta6~6_api/meta.window#method-move_resize_frame
+     */
+    move_resize_frame(userOp: boolean, rootXNW: number, rootYNW: number, width: number, height: number): void;
+}
+
+/**
+ * Type definition based on https://gjs-docs.gnome.org/meta6~6_api/meta.rectangle.
+ */
+interface MetaRectangle {
+    readonly x: number;
+    readonly y: number;
+    readonly width: number;
+    readonly height: number;
+}
+
+/**
  * Resize & move the *window* so it touches adjacent windows or
  * screen edge top, bottom, left and right. The top-left corner 
  * of the window defines the expansion point. 
@@ -121,10 +141,10 @@ function expandVertically(y, left, right, miny, maxy, windows) {
  * both vertically and horizontally. The expnasion that results
  * in closer to 1 aspect ratio is selected. 
  */
-function snapToNeighbors(window) {
+export function snapToNeighbors(window: MetaWindow) {
 	log("snapToNeighbors " + window.get_title());
     // Unmaximize first
-    if (window.maximized_horizontally || window.maximizedVertically)
+    if (window.maximized_horizontally || window.maximized_vertically)
         window.unmaximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
 
     let workArea = window.get_work_area_current_monitor();


### PR DESCRIPTION
My previous commit broke the extension because of unresolved references to logging.js. This change converts hotkeys.js and snaptoneighbors.js to Typescript, which makes importing them safer.