### PR TITLE
Move destroy grids call after launcher destroy is called

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -402,9 +402,9 @@ export function disable() {
         unbindHotkeys(key_bindings_tiling);
         keyControlBound = false;
     }
-    destroyGrids();
     launcher.destroy();
     launcher = null;
+    destroyGrids();
     resetFocusMetaWindow();
     log("Extention Disabled!");
 }


### PR DESCRIPTION
When `destroyGrids` function call fails the laucher is not correctly destroyead what leads to GTileStatusButton still registered in the StatusArea. It is impossible then to reload the plugin as the environment complains with the following error `JS ERROR: Extension gTile@vibou: Error: Extension point conflict: there is already a status indicator for role GTileStatusButton`. Following PR moves the `destroyGrids` function call after the launcher.destroy() call.