### PR TITLE
Update app.ts, move_frame before move_resize_frame

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -617,7 +617,7 @@ function move_resize_window_with_margins(metaWindow, x, y, width, height){
     height = height - 2 * vBorderY ;
     log("After margins and visible border window is " + x + ":" + y + " - " + width + ":" + height);
 
-    metaWindow.move_frame(true, x, y, width, height);
+    metaWindow.move_frame(true, x, y);
     metaWindow.move_resize_frame(true, x, y, width, height);
 }
 

--- a/app.ts
+++ b/app.ts
@@ -617,6 +617,7 @@ function move_resize_window_with_margins(metaWindow, x, y, width, height){
     height = height - 2 * vBorderY ;
     log("After margins and visible border window is " + x + ":" + y + " - " + width + ":" + height);
 
+    metaWindow.move_frame(true, x, y, width, height);
     metaWindow.move_resize_frame(true, x, y, width, height);
 }
 


### PR DESCRIPTION
Resolves to: https://github.com/gTile/gTile/issues/176#issue-751198339

After a recent update, I noticed that all of my windows would properly resize, except gnome-terminal.
gnome-terminal would resize properly, but not move.
Examining the logs for gTile, the coordinates looked correct. After experimenting in Looking Glass for a bit it, I found that when following this same flow, (get windows from active_workspace, iterate to find the has_focus, and move_resize_frame), the window would resize but wouldn't always move. However, running move_frame, before or after always worked.
I added this change locally, restarted my session, and it fixed the issue with gnome-shell.

I'm running:
Debian 5.9.1-1kali2
GNOME Shell 3.38.1
gtk-launch --version: 3.24.23
version number:    11.0
X.Org version: 1.20.8