### PR TITLE
changing the icon to work for dark or light themes

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -41,6 +41,7 @@ const WorkspaceManager: WorkspaceManagerInterface = (
 
 // Extension imports
 const Me = imports.misc.extensionUtils.getCurrentExtension();
+const Gio = imports.gi.Gio;
 const Settings = Me.imports.settings;
 
 interface WorkArea {
@@ -655,7 +656,10 @@ const GTileStatusButton = new Lang.Class({
         this.parent(0.0, "gTile", false);
         //Done by default in PanelMenuButton - Just need to override the method
         if (SHELL_VERSION.version_at_least_34()) {
-            this.add_style_class_name(classname);
+            this._icon = new St.Icon({ style_class: 'system-status-icon' });
+            this._icon.gicon = Gio.icon_new_for_string(Me.path + "/images/icon.svg");
+            this.add_actor(this._icon);
+            this.add_style_class_name('panel-status-button');
             this.connect('button-press-event', Lang.bind(this, this._onButtonPress));
         } else {
             this.actor.add_style_class_name(classname);

--- a/images/icon.svg
+++ b/images/icon.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333333 4.2333333"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)"
+   sodipodi:docname="test.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="30.809852"
+     inkscape:cx="4.9988305"
+     inkscape:cy="11.711303"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     showborder="false"
+     inkscape:window-width="1413"
+     inkscape:window-height="1205"
+     inkscape:window-x="26"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     units="px" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:#808080;fill-opacity:1;stroke-width:0.264583"
+       id="rect1520"
+       width="1.8532557"
+       height="3.9674809"
+       x="0.1586881"
+       y="0.1239212" />
+    <rect
+       style="fill:#808080;fill-opacity:1;stroke-width:0.268523"
+       id="rect1522"
+       width="1.8486881"
+       height="1.903842"
+       x="2.1576505"
+       y="0.1239212" />
+    <rect
+       style="fill:#808080;fill-opacity:1;stroke-width:0.268523"
+       id="rect1564"
+       width="1.8486881"
+       height="1.903842"
+       x="2.1576505"
+       y="2.1875579" />
+  </g>
+</svg>


### PR DESCRIPTION
For #203 
My inkscape skills are terrible, but I gave it a shot.  Also, I didn't figure out how bazel works, but these changes work fine when I apply them to my local install.
New light mode:
![image](https://user-images.githubusercontent.com/8107932/112220162-8d5a1a80-8beb-11eb-9902-799687c009de.png)
New dark mode:
![image](https://user-images.githubusercontent.com/8107932/112220214-9ba83680-8beb-11eb-8d9e-0f5e91a60c9e.png)
