### PR TITLE
Change shell-version metadata to be 40

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
     "3.35",
     "3.36",
     "3.38",
-    "40.0"
+    "40"
   ],
   "url": "https://github.com/gTile",
   "settings-schema": "org.gnome.shell.extensions.gtile",


### PR DESCRIPTION
Currently the extension is marked not compatible with 40.1 on https://extensions.gnome.org/.

Changing the version from 40.0 to 40 appears to fix this and allows it to load on and updated Fedora 34.

This seems to be a common pattern, for example:

https://github.com/ubuntu/gnome-shell-extension-appindicator/blob/master/metadata.json#L7

Which does "work" in Gnome 40.1