### PR TITLE
Fixup for consistent 2x3 scheme defaults

### DIFF
--- a/schemas/org.gnome.shell.extensions.gtile.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.gtile.gschema.xml
@@ -363,7 +363,7 @@
 			<summary>Preset resize11 settings.</summary>
 		</key>
 		<key type = "s" name="resize12">
-			<default>'3x3 0:2 1:2'</default>
+			<default>'2x3 0:2 1:2'</default>
 			<summary>Preset resize12 settings.</summary>
 		</key>
 		<key type = "s" name="resize13">


### PR DESCRIPTION
Super + Control <8, 5, 2> should fill entire screen using 2x3 grid

See the neighboring `resize11` through `resize19` lines which all use `2x3`.

There's another note about this typo in https://github.com/gTile/gTile/pull/5/files#r146127144