### PR TITLE
Add support for GNOME 41

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,8 @@
     "3.35",
     "3.36",
     "3.38",
-    "40"
+    "40",
+    "41"
   ],
   "url": "https://github.com/gTile",
   "settings-schema": "org.gnome.shell.extensions.gtile",


### PR DESCRIPTION
GNOME 41 beta has been released and is in Fedora 35 pre-releases. As near as I can tell, it operates properly with no changes other than the metadata.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>