### PR TITLE
Fix default, minimal dark and minimal light themes

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -63,7 +63,7 @@
 
 .gtile-default__tile-table-item {
     background-color: rgba(238, 238, 236, 0.3);
-    margin: 5px;
+    margin: 1px;
     border-radius: 2px;
 }
 
@@ -92,9 +92,12 @@
     background-color: rgba(238, 238, 236, 0.1);
     border-radius: 20px;
     padding: 0;
-    margin: 5px;
+    margin: 0 0 0 5px;
     font-size: 12px;
     line-height: 12px;
+}
+.gtile-default__preset-button:first-child {
+    margin-left: 0;
 }
 
 .gtile-default__preset-button:hover,
@@ -145,7 +148,8 @@
 .gtile-default__action {
     spacing-rows: 0px;
     spacing-columns: 2px;
-    margin: 15px 0px 15px 32px;
+    padding: 0px 0px 15px 32px;
+    margin: 15px 0 32px;
 }
 
 .gtile-default__action-button {
@@ -456,7 +460,6 @@
     background-image: url("images/icons/light/32/close.png");
     padding: 2px;
     padding-left: 5px;
-    padding-left: 5px;
     border-radius: 50px;
     border-width: 1px;
 }
@@ -481,7 +484,7 @@
 
 .gtile-minimal-dark__tile-table-item {
     background-color: #4b4b4b;
-    margin: 2px;
+    margin: 1px;
     border-radius: 2px;
 }
 
@@ -503,14 +506,17 @@
 }
 
 .gtile-minimal-dark__preset-container {
-  padding: 10px 0px 0px 0px;
+  padding: 10px 5px 10px 5px;
 }
 
 .gtile-minimal-dark__preset-button {
     background-color: #4b4b4b;
     border-radius: 8px;
-    margin: 4px;
-    padding: 4px;
+    padding: 0 4px;
+    margin: 0 0 0 4px;
+}
+.gtile-minimal-dark__preset-button:first-child {
+    margin-left: 0;
 }
 
 .gtile-minimal-dark__preset-button:hover,
@@ -560,7 +566,8 @@
 }
 
 .gtile-minimal-dark__action-container {
-    padding:2px 0px 10px 0px;
+    padding: 2px 0px 10px 0px;
+    margin-bottom: 20px;
 }
 
 .gtile-minimal-dark__action-button {
@@ -622,7 +629,7 @@
  * Main container
  */
 
- .gtile-minimal-light {
+.gtile-minimal-light {
     background-color: #f6f5f4;
     -webkit-filter: blur(2px);
     width:320px;
@@ -632,146 +639,149 @@
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.397);
     border-color: #cdc7c2;
     border-width: 1px;
-  }
-  
-  
-  /**
-  * Title bar
-  */
-  
-  .gtile-minimal-light__title-container {
-  padding: 3px;
-  }
-  
-  .gtile-minimal-light__title {
+}
+
+
+/**
+* Title bar
+*/
+
+.gtile-minimal-light__title-container {
+    padding: 3px;
+}
+
+.gtile-minimal-light__title {
     font-size: 12px;
     color: #111111;
     padding: .5em;
     text-align: center;
-  }
-  
-  .gtile-minimal-light__close-container {
+}
+
+.gtile-minimal-light__close-container {
     background-color: rgba(0,120,255,0);
-  }
-  
-  .gtile-minimal-light__close {
+}
+
+.gtile-minimal-light__close {
     background-size: 22px 22px;
     height: 20px;
     width: 20px;
     background-image: url("images/icons/dark/32/close.png");
     padding: 2px;
     padding-left: 5px;
-    padding-left: 5px;
     border-radius: 50px;
     border-width: 1px;
-  }
-  
-  .gtile-minimal-light__close:hover {
+}
+
+.gtile-minimal-light__close:hover {
     background-color: #cccac7;
     border-color: #cccac7;
-  }
-  
-  
-  /**
-  * Tile container
-  */
-  
-  .gtile-minimal-light__tile-container {}
-  
-  .gtile-minimal-light__tile-table {
+}
+
+
+/**
+* Tile container
+*/
+
+.gtile-minimal-light__tile-container {}
+
+.gtile-minimal-light__tile-table {
     spacing-rows: 2px;
     spacing-columns: 2px;
     padding: 4px;
   }
-  
-  .gtile-minimal-light__tile-table-item {
+
+.gtile-minimal-light__tile-table-item {
     background-color: #b1aca9;
-    margin: 2px;
+    margin: 1px;
     border-radius: 2px;
-  }
-  
-  .gtile-minimal-light__tile-table-item:activate {
+}
+
+.gtile-minimal-light__tile-table-item:activate {
     background-color: #928f8c;
-  }
-  
-  
-  /**
-  * Preset container
-  */
-  
-  .gtile-minimal-light__preset-container {
-  }
-  
-  .gtile-minimal-light__preset {
-  spacing-rows: 0px;
-  spacing-columns: 2px;
-  }
-  
-  .gtile-minimal-light__preset-container {
-  padding: 10px 0px 0px 0px;
-  }
-  
-  .gtile-minimal-light__preset-button {
+}
+
+
+/**
+* Preset container
+*/
+
+.gtile-minimal-light__preset-container {
+}
+
+.gtile-minimal-light__preset {
+    spacing-rows: 0px;
+    spacing-columns: 2px;
+}
+
+.gtile-minimal-light__preset-container {
+    padding: 10px 5px 10px 5px;
+}
+
+.gtile-minimal-light__preset-button {
     color: #111111;
     background-color: #f7f6f6;
     border-radius: 8px;
     border-width: 1px;
     border-color: #c9c3bd;
-    margin: 4px;
-    padding: 4px;
-  }
-  
-  .gtile-minimal-light__preset-button:hover,
-  .gtile-minimal-light__preset-button:activate {
+    padding: 0 4px;
+    margin: 0 0 0 4px;
+}
+.gtile-minimal-light__preset-button:first-child {
+    margin-left: 0;
+}
+
+.gtile-minimal-light__preset-button:hover,
+.gtile-minimal-light__preset-button:activate {
     background-color: #e8e6e3;
-  }
-  
-  
-  /**
-  * Actions container
-  */
-  .gtile-minimal-light__action-button--animation,
-  .gtile-minimal-light__action-button--auto-close,
-  .gtile-minimal-light__action-button--main-and-list,
-  .gtile-minimal-light__action-button--two-list{
+}
+
+
+/**
+* Actions container
+*/
+.gtile-minimal-light__action-button--animation,
+.gtile-minimal-light__action-button--auto-close,
+.gtile-minimal-light__action-button--main-and-list,
+.gtile-minimal-light__action-button--two-list{
     background-size: 32px 32px;
     height:34px;
     width:34px;
-  }
-  
-  .gtile-minimal-light__action-button--animation {
+}
+
+.gtile-minimal-light__action-button--animation {
     background-image: url("images/icons/dark/32/animation.png");
-  }
-  
-  .gtile-minimal-light__action-button--auto-close {
+}
+
+.gtile-minimal-light__action-button--auto-close {
     background-image: url("images/icons/dark/32/auto-close.png");
-  }
-  
-  .gtile-minimal-light__action-button--main-and-list {
+}
+
+.gtile-minimal-light__action-button--main-and-list {
     background-image: url("images/icons/dark/32/auto-tile-0.png");
-  }
-  
-  .gtile-minimal-light__action-button--two-list {
+}
+
+.gtile-minimal-light__action-button--two-list {
     background-image: url("images/icons/dark/32/auto-tile-1.png");
-  }
-  
-  .gtile-minimal-light__action-button--scale {
+}
+
+.gtile-minimal-light__action-button--scale {
     background-image: url("images/icons/dark/32/scale.png");
     background-size: 36px 36px;
     height:36px;
     width:36px;
-  }
-  
-  .gtile-minimal-light__action {
-  spacing-rows: 0px;
-  spacing-columns: 2px;
-  }
-  
-  .gtile-minimal-light__action-container {
-    padding:2px 0px 10px 0px;
-  }
-  
-  .gtile-minimal-light__action-button {
+}
+
+.gtile-minimal-light__action {
+    spacing-rows: 0px;
+    spacing-columns: 2px;
+}
+
+.gtile-minimal-light__action-container {
+    padding: 2px 0px 10px 0px;
+    margin-bottom: 20px;
+}
+
+.gtile-minimal-light__action-button {
     color: #111111;
     background-color: #f7f6f6;
     border-radius: 8px;
@@ -779,50 +789,49 @@
     border-color: #c9c3bd;
     margin: 4px;
     padding: 4px;
-  }
-  
-  .gtile-minimal-light__action-button:hover,
-  .gtile-minimal-light__action-button:activate {
-    background-color: #e8e6e3;
-  }
+}
 
-  .gtile-minimal-light__grid_lines_preview {
+.gtile-minimal-light__action-button:hover,
+.gtile-minimal-light__action-button:activate {
+    background-color: #e8e6e3;
+}
+
+.gtile-minimal-light__grid_lines_preview {
     background-color: rgba(0,0,0,0);
     border: 1px solid rgba(217,108,59,0.8);
 }
-  
-  
-  /**
-  * Grid preview
-  */
-  
-  .gtile-minimal-light__preview {
+
+
+/**
+* Grid preview
+*/
+
+.gtile-minimal-light__preview {
     background-color: rgba(241,122,73,0.0);
     border: rgba(217,108,59,0.0);
-  }
-  
-  .gtile-minimal-light__preview:activate {
+}
+
+.gtile-minimal-light__preview:activate {
     background-color: rgba(241,122,73,0.4);
     border: 1px solid rgba(217,108,59,0.8);
-  }
-  
-  
-  /**
-  * Panel icon
-  */
-  
-  .gtile-minimal-light__icon {
+}
+
+
+/**
+* Panel icon
+*/
+
+.gtile-minimal-light__icon {
     width: 24px;
     height: 24px;
     background-image: url("images/launcher/dark/16/default.png");
     background-size: 16px 16px;
-  }
-  
-  .gtile-minimal-light__icon:hover {
-  background-image: url("images/launcher/dark/16/hover.png");
-  }
-  
-  .gtile-minimal-light__icon:activate {
-  background-image: url("images/launcher/dark/16/active.png");
-  }
-  
+}
+
+.gtile-minimal-light__icon:hover {
+    background-image: url("images/launcher/dark/16/hover.png");
+}
+
+.gtile-minimal-light__icon:activate {
+    background-image: url("images/launcher/dark/16/active.png");
+}


### PR DESCRIPTION
This PR fixes issues with UI on gnome-shell with Default, Minimal Dark and Minimal Light themes on 2k-4k monitors

@ref https://github.com/gTile/gTile/issues/60
@ref https://github.com/gTile/gTile/issues/261

How it was:

![gTile-buggy](https://user-images.githubusercontent.com/2429298/172493408-45c3b46b-8338-4f89-8d3f-10f89715e1a1.png)

This PR makes this:

![gTile-fixed](https://user-images.githubusercontent.com/2429298/172493450-90dc2e57-5e7f-4629-a9e5-eecf54c13e5f.png)

