### PR TITLE
metadata.json: Support for Gnome 43

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,8 @@
     "3.38",
     "40",
     "41",
-    "42"
+    "42",
+    "43"
   ],
   "url": "https://github.com/gTile",
   "settings-schema": "org.gnome.shell.extensions.gtile",


### PR DESCRIPTION
I've tested this change in my Fedora rawhide with Gnome 43 and it runs without apparent issues.