### PR TITLE
Compatibility for gnome.extensions.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 CHANGE LOG
 ----------
+### 55
+- Satisfy non-functional requirements to be publishable on extensions.gnome.org.
+
 ### 54
 - Add preferences dialog
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ npm run install:extension
 After restarting your Gnome shell session you can enable the extension via:
 
 ```shell
-$ gnome-extensions enable gTile@vibou
+gnome-extensions enable gTile@vibou
 ```
 
 ## Configuration
@@ -235,7 +235,7 @@ npm ci
 
 ## Workflow
 
-Testing changes can be tedious at times because an extension cannot be updated in-place. The Gnome shell session must be restarted in order for changes to take effect. In Wayland it is usually much easier to start a nested session instead. Check the [GJS documentation](https://gjs.guide/extensions/development/debugging.html#reloading-extensions) on how to best debug extensions. Note that nested gnome sessions can take time to load and do not allow to test multi-screen setups. I personally found it most productive to have a second remote system which I used to continuously test the extension on. For this purpose I added a simple new script to `package.json`:
+Testing changes can be tedious at times because an extension cannot be updated in-place. The Gnome shell session must be restarted in order for changes to take effect. In Wayland it is usually much easier to start a nested session instead. Check the [GJS documentation](https://gjs.guide/extensions/development/debugging.html#reloading-extensions) on how to best debug extensions. Note that nested gnome sessions can take time to load and does not allow to test multi-screen setups. I personally found it most productive to have a second remote system which I used to continuously test the extension on. For this purpose I added a simple new script to `package.json`:
 
 ```json
 {
@@ -280,12 +280,12 @@ src                 - The TypeScript root directory
 └── prefs.ts        - The entry point for the preferences dialog
 ```
 
-Note that `src/types/` must not contain any files that emit actual JS runtime code. Any files emited by `tsc` during transpilation are deleted by the `postbuild` script in `package.json`.
+Note that `src/types/` must not contain any files that emit actual JS runtime code. Transpiled files in `dist/types/` (as emited by `tsc` during transpilation) are deleted by the `postbuild` script in `package.json`.
 
 ## Design Principles
-The code base follows the [SOLID](https://en.wikipedia.org/wiki/SOLID) paradigm __up to an extend__. Although it doesn't strictly follow the paradigm it is definitely architectured with these principles in mind. Try to stick with these principles when changing the architecture, e.g., to make [adaptation for different desktop environments](https://github.com/gTile/gTile/issues/103) more easy.
+The code base follows the [SOLID](https://en.wikipedia.org/wiki/SOLID) paradigm __up to an extend__. Although it doesn't strictly follow the paradigm it is definitely architectured with these principles in mind. Try to stick with these principles when changing the architecture, e.g., to ease [adaptation for different desktop environments](https://github.com/gTile/gTile/issues/103).
 
-The extension make use of the GJS mechanisms where possible. In particular, the UI components make extensive use of GObject [Properties and Signals](https://gjs.guide/guides/gobject/basics.html) for synchronization purposes. UI components are modeled as general purpose, composable components. In particular, they do not contain any logic other than strictly related to rendering. Business logic is supposed to reside in an orchestrating class of function.
+The extension makes use of the GJS mechanisms where possible. In particular, the UI components make extensive use of GObject [Properties and Signals](https://gjs.guide/guides/gobject/basics.html) for synchronization purposes. UI components are modeled as general purpose, composable components. In particular, they do not contain any logic other than strictly related to rendering. Business logic is supposed to reside in an orchestrating class or function.
 
 ## Code Style Guide
 The project does intentionally avoid the use of linters such as prettier or eslint. Quick comprehension is more important than following strict code formatting rules. That being said, please try to comply with the implicit code style used throughout the code base. In particular:

--- a/dist/metadata.json
+++ b/dist/metadata.json
@@ -5,5 +5,5 @@
   "shell-version": ["45"],
   "url": "https://github.com/gTile",
   "settings-schema": "org.gnome.shell.extensions.gtile",
-  "version": 54
+  "version": 55
 }

--- a/src/core/App.ts
+++ b/src/core/App.ts
@@ -145,6 +145,7 @@ export default class App implements GarbageCollector {
 
   release() {
     this.#gc.release();
+    this.#lastResizePreset.release();
     App.#instance = undefined as any;
   }
 

--- a/src/core/App.ts
+++ b/src/core/App.ts
@@ -1,5 +1,5 @@
-import Gio from "gi://Gio?version=2.0";
-import Shell from "gi://Shell?version=13";
+import Gio from "gi://Gio";
+import Shell from "gi://Shell";
 
 import * as Main from "resource:///org/gnome/shell/ui/main.js";
 

--- a/src/core/DesktopManager.ts
+++ b/src/core/DesktopManager.ts
@@ -1,6 +1,6 @@
-import Meta from "gi://Meta?version=13";
-import Mtk from "gi://Mtk?version=13";
-import Shell from "gi://Shell?version=13";
+import Meta from "gi://Meta";
+import Mtk from "gi://Mtk";
+import Shell from "gi://Shell";
 
 import type { LayoutManager, Monitor } from "resource:///org/gnome/shell/ui/layout.js";
 

--- a/src/core/DesktopManager.ts
+++ b/src/core/DesktopManager.ts
@@ -214,6 +214,8 @@ export default class implements Publisher<DesktopEvent>, GarbageCollector {
    *
    * @param window The window whose position & size should be mapped.
    * @param gridSize Reference grid size for which the selection is calculated.
+   * @param snap Optional. The strategy to be used when the window edges do not
+   *   perfectly align with the grid.
    * @returns The mapped selection.
    */
   windowToSelection(

--- a/src/core/HotkeyManager.ts
+++ b/src/core/HotkeyManager.ts
@@ -1,5 +1,5 @@
-import Meta from "gi://Meta?version=13";
-import Shell from "gi://Shell?version=13";
+import Meta from "gi://Meta";
+import Shell from "gi://Shell";
 
 import { WindowManager } from "resource:///org/gnome/shell/ui/windowManager.js";
 

--- a/src/core/OverlayManager.ts
+++ b/src/core/OverlayManager.ts
@@ -298,6 +298,7 @@ export default class implements Publisher<OverlayEvent>, GarbageCollector {
     let overlay: InstanceType<typeof Overlay>, wasVisible = false;
     while (overlay = this.#overlays.pop()!) {
       wasVisible ||= overlay.visible;
+      overlay.release();
       overlay.destroy();
     }
 

--- a/src/core/OverlayManager.ts
+++ b/src/core/OverlayManager.ts
@@ -1,6 +1,6 @@
-import Gio from "gi://Gio?version=2.0";
-import Meta from "gi://Meta?version=13";
-import St from "gi://St?version=13";
+import Gio from "gi://Gio";
+import Meta from "gi://Meta";
+import St from "gi://St";
 
 import type { LayoutManager } from "resource:///org/gnome/shell/ui/layout.js";
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-import GLib from "gi://GLib?version=2.0";
+import GLib from "gi://GLib";
 
 import { Extension } from "resource:///org/gnome/shell/extensions/extension.js";
 

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -45,10 +45,11 @@ export default class extends ExtensionPreferences {
 
   #release() {
     this.#gc.release();
-    // do NOT set #settings or other instance variables to undefined! This would
-    // cause the GC to dereference and cleanup resources before GJS expects them
-    // to be gone (even long after the preference window was closed). Would
-    // cause errors like these:
+    this.#gc = undefined!;
+    this.#settings = undefined!;
+    // do NOT set #window to undefined! This would cause the GC to dereference
+    // and cleanup resources before GJS expects them to be gone (even long after
+    // the preference window was closed). Would cause errors like these:
     // - instance with invalid (NULL) class pointer
     // - g_signal_handlers_disconnect_matched: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed
   }
@@ -566,6 +567,7 @@ const ShortcutRow = GObject.registerClass({
 
       switch (keyval) {
         case Gdk.KEY_Escape:
+          // triggers "response" callback
           dialog.close();
           return Gdk.EVENT_STOP;
         case Gdk.KEY_BackSpace:

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -1,9 +1,9 @@
-import Adw from "gi://Adw?version=1";
-import Gdk from "gi://Gdk?version=4.0";
-import GObject from "gi://GObject?version=2.0";
-import Gio from "gi://Gio?version=2.0";
-import Gtk from "gi://Gtk?version=4.0";
-import Pango from "gi://Pango?version=1.0";
+import Adw from "gi://Adw";
+import Gdk from "gi://Gdk";
+import GObject from "gi://GObject";
+import Gio from "gi://Gio";
+import Gtk from "gi://Gtk";
+import Pango from "gi://Pango";
 
 import {
   ExtensionPreferences

--- a/src/types/desktop.ts
+++ b/src/types/desktop.ts
@@ -1,4 +1,4 @@
-import Meta from "gi://Meta?version=13";
+import Meta from "gi://Meta";
 
 /**
  * Represents an event that is related to the desktop environment of the user.

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,5 +1,5 @@
-import Gio from "gi://Gio?version=2.0";
-import GObject from "gi://GObject?version=2.0";
+import Gio from "gi://Gio";
+import GObject from "gi://GObject";
 
 import { Extension } from "resource:///org/gnome/shell/extensions/extension.js";
 

--- a/src/ui/Overlay.ts
+++ b/src/ui/Overlay.ts
@@ -1,6 +1,6 @@
-import GLib from "gi://GLib?version=2.0";
-import GObject from "gi://GObject?version=2.0";
-import St from "gi://St?version=13";
+import GLib from "gi://GLib";
+import GObject from "gi://GObject";
+import St from "gi://St";
 
 import { GridOffset, GridSelection, GridSize } from "../types/grid.js";
 import { Theme } from "../types/theme.js";

--- a/src/ui/Overlay.ts
+++ b/src/ui/Overlay.ts
@@ -4,6 +4,7 @@ import St from "gi://St?version=13";
 
 import { GridOffset, GridSelection, GridSize } from "../types/grid.js";
 import { Theme } from "../types/theme.js";
+import { GarbageCollector } from "../util/gc.js";
 import ButtonBar from "./overlay/ButtonBar.js";
 import Container from "./overlay/Container.js";
 import Grid from "./overlay/Grid.js";
@@ -108,7 +109,7 @@ export default GObject.registerClass({
      */
     selected: {},
   }
-}, class extends St.BoxLayout {
+}, class extends St.BoxLayout implements GarbageCollector {
   #theme: Theme;
   #titleBar: InstanceType<typeof TitleBar>;
   #grid: InstanceType<typeof Grid>;
@@ -189,6 +190,13 @@ export default GObject.registerClass({
     this.#grid.connect("selected", () => this.emit("selected"));
     this.connect("notify::visible", () => { this.gridSelection = null; });
     this.connect("notify::hover", this.#onHoverChanged.bind(this));
+  }
+
+  release(): void {
+    if (this.#delayTimeoutID) {
+      clearTimeout(this.#delayTimeoutID);
+      this.#delayTimeoutID = null;
+    }
   }
 
   /**

--- a/src/ui/PanelButton.ts
+++ b/src/ui/PanelButton.ts
@@ -1,5 +1,5 @@
-import GObject from "gi://GObject?version=2.0"
-import St from "gi://St?version=13";
+import GObject from "gi://GObject"
+import St from "gi://St";
 
 import * as PanelMenu from "resource:///org/gnome/shell/ui/panelMenu.js";
 

--- a/src/ui/Preview.ts
+++ b/src/ui/Preview.ts
@@ -1,5 +1,5 @@
-import GObject from "gi://GObject?version=2.0";
-import St from "gi://St?version=13";
+import GObject from "gi://GObject";
+import St from "gi://St";
 
 import { Rectangle } from "../types/grid.js";
 import { Theme } from "../types/theme.js";

--- a/src/ui/overlay/ButtonBar.ts
+++ b/src/ui/overlay/ButtonBar.ts
@@ -1,6 +1,6 @@
-import Clutter from "gi://Clutter?version=13";
-import GObject from "gi://GObject?version=2.0";
-import St from "gi://St?version=13";
+import Clutter from "gi://Clutter";
+import GObject from "gi://GObject";
+import St from "gi://St";
 
 import { Theme } from "../../types/theme.js";
 

--- a/src/ui/overlay/Container.ts
+++ b/src/ui/overlay/Container.ts
@@ -1,5 +1,5 @@
-import GObject from "gi://GObject?version=2.0";
-import St from "gi://St?version=13";
+import GObject from "gi://GObject";
+import St from "gi://St";
 
 import { Theme } from "../../types/theme.js";
 

--- a/src/ui/overlay/Grid.ts
+++ b/src/ui/overlay/Grid.ts
@@ -1,6 +1,6 @@
-import Clutter from "gi://Clutter?version=13";
-import GObject from "gi://GObject?version=2.0";
-import St from "gi://St?version=13";
+import Clutter from "gi://Clutter";
+import GObject from "gi://GObject";
+import St from "gi://St";
 
 import { GridOffset, GridSize, GridSelection } from "../../types/grid.js";
 import { Theme } from "../../types/theme.js";

--- a/src/ui/overlay/IconButton.ts
+++ b/src/ui/overlay/IconButton.ts
@@ -1,5 +1,5 @@
-import GObject from "gi://GObject?version=2.0";
-import St from "gi://St?version=13";
+import GObject from "gi://GObject";
+import St from "gi://St";
 
 import { Theme } from "../../types/theme.js";
 import TextButton, { ButtonParams } from "./TextButton.js";

--- a/src/ui/overlay/TextButton.ts
+++ b/src/ui/overlay/TextButton.ts
@@ -1,5 +1,5 @@
-import GObject from "gi://GObject?version=2.0";
-import St from "gi://St?version=13";
+import GObject from "gi://GObject";
+import St from "gi://St";
 
 import { Theme } from "../../types/theme.js";
 

--- a/src/ui/overlay/TitleBar.ts
+++ b/src/ui/overlay/TitleBar.ts
@@ -1,6 +1,6 @@
-import Clutter from "gi://Clutter?version=13";
-import GObject from "gi://GObject?version=2.0";
-import St from "gi://St?version=13";
+import Clutter from "gi://Clutter";
+import GObject from "gi://GObject";
+import St from "gi://St";
 
 import { Theme } from "../../types/theme.js"
 

--- a/src/util/gc.ts
+++ b/src/util/gc.ts
@@ -22,7 +22,7 @@ export class GarbageCollection implements GarbageCollector {
   }
 
   /**
-   * Executes all deferred cleanup routines in reverse order, i.e. LIFO.
+   * Executes all deferred cleanup routines in reverse order, i.e., LIFO.
    */
   release() {
     while (this.#routines.length > 0) {

--- a/src/util/volatile.ts
+++ b/src/util/volatile.ts
@@ -1,4 +1,4 @@
-import { GarbageCollection } from "./gc.js";
+import { GarbageCollection, GarbageCollector } from "./gc.js";
 
 /**
  * Provides a volatile storage for values of type {@link T}. The store
@@ -8,7 +8,7 @@ export interface VolatileStore<T> {
   store: T | null;
 }
 
-export class VolatileStorage<T> implements VolatileStore<T> {
+export class VolatileStorage<T> implements VolatileStore<T>, GarbageCollector {
   #gc: GarbageCollection
   #timeout: number;
   #stored: T | null;
@@ -22,6 +22,10 @@ export class VolatileStorage<T> implements VolatileStore<T> {
     this.#gc = new GarbageCollection();
     this.#timeout = lifetime;
     this.#stored = null;
+  }
+
+  release(): void {
+    this.#gc.release();
   }
 
   /**


### PR DESCRIPTION
The latest version of gTile was rejected from being published on gnome.extensions.org.
See https://extensions.gnome.org/review/48580

This PR addresses the points raised by @jrahmatzadeh. I would appreciate if you could directly review to this PR, so we can skip unnecessary review-loops on EGO.

> 1. Don't use version when importing.

I am [still not convinced](https://github.com/oae/gnome-shell-pano/pull/222#issuecomment-1812880830) how this helps with type-safe development. But I gather from your [comment](https://github.com/oae/gnome-shell-pano/pull/222#issuecomment-1814075558) that you specifically refer to versioned imports that are also a direct dependency to `gnome-shell`. This only concerns the `Gio` and `Gtk` imports in this project. I've removed the version constrain from all of those imports in this PR.

> 2. Also null out on destroy (line 26 `prefs.js`):
>  ```js
>    this.#gc = null;
>    this.#settings = null;
>    this.#window = null;
>    ```

When I did that, I experienced a few errors while monitoring the logs from `/usr/bin/gjs` and `/usr/bin/gnome-shell`. I even left a comment about that in the [code base](https://github.com/gTile/gTile/blob/1ba3ac3951a2aa15867ae7f182e54abf9ed4585f/src/prefs.ts#L48-L53). Please have a look at it.

You can reproduce the errors by adding the lines you suggested. Then:
1. Make sure that `prefs.js` wasn't yet loaded by gnome-shell (so that the changes made take effect)
2. Open the preference dialog of the extension.
3. Set a shortcut for an arbitrary action (I believe this wasn't even required to trigger the errors)
4. Close the preference dialog
5. Now logout from the gnome session.
    - Note: I observed the logs remotely via SSH
6. You should see the errors that I referenced in the comment above.

> 3. Where do you remove the keybindings on disable in `core/HotkeyManager.js`?

In [`HotkeyManager::release()`](https://github.com/gTile/gTile/blob/1ba3ac3951a2aa15867ae7f182e54abf9ed4585f/src/core/HotkeyManager.ts#L97-L106).  Note the `this.#keyBindingGroupMask = 0` assignment. That causes all keybindings to be unregistered by the `register*Hotkeys()` calls that follow.

> 4. Timeouts should be removed on destroy:
>
>  - line 163 `ui/Overlay.js`
>  - line 14 `util/volatile.js`
>  - line 206 `core/OverlayManager.js`
>
>  [EGO Review Guidelines: Timeout](https://gjs.guide/extensions/review-guidelines/review-guidelines.html#remove-main-loop-sources)

The guideline you are referencing is using `GLib.timeout_add_seconds()` and `GLib.Source.remove()` in the example code. I was under the impression that a call to `setTimeout()` would merely require a call to `clearTimeout()` when destroying. Is that assumption correct? Or do I have to explicitly call `GLib.Source.remove`?