### PR TITLE
Fix typo in "contract-down" setting description

### DIFF
--- a/dist/schemas/org.gnome.shell.extensions.gtile.gschema.xml
+++ b/dist/schemas/org.gnome.shell.extensions.gtile.gschema.xml
@@ -55,7 +55,7 @@
     </key>
     <key type="as" name="contract-down">
       <default><![CDATA[['<Shift>Up', '<Shift>k']]]></default>
-      <summary>Contract top window edge upwards</summary>
+      <summary>Contract bottom window edge upwards</summary>
     </key>
     <key type="as" name="expand-left">
       <default><![CDATA[[]]]></default>


### PR DESCRIPTION
The "contract-down" action moves the bottom window edge upwards. Correct the key's summary by changing it from "Contract top window edge upwards" to "Contract bottom window edge upwards".