### PR TITLE
Ignore “Always Above” windows during autotiling

### DIFF
--- a/src/core/DesktopManager.ts
+++ b/src/core/DesktopManager.ts
@@ -304,7 +304,6 @@ export default class implements Publisher<DesktopEvent>, GarbageCollector {
     const collisionWindows = workspace.list_windows().filter(win => !(
       win === target ||
       win.minimized ||
-      win.is_above() ||
       win.get_frame_type() !== Meta.FrameType.NORMAL ||
       TitleBlacklist.some(p => p.test(win.title ?? "")) ||
       win.get_monitor() !== monitorIdx ||


### PR DESCRIPTION
This pull request updates the autotiling logic to ignore windows that are marked as always above (using `win.is_above()`).

### Technical note:
AFAIK this "Always Above" behavior can only be set manuall1 by a hidden keybinding in the dconf editor (the keybinding is called `toggle_above`)

### Rationale:
Just like minimized windows are currently ignored by autotiling, it makes sense to also skip always above windows. These are typically small, floating windows like a webcam preview or sticky overlay, that users intentionally keep visible and untiled.