### PR TITLE
Fix for autotile window ordering regression

### DIFF
--- a/src/core/DesktopManager.ts
+++ b/src/core/DesktopManager.ts
@@ -383,7 +383,6 @@ export default class implements Publisher<DesktopEvent>, GarbageCollector {
         win.get_frame_type() !== Meta.FrameType.NORMAL ||
         TitleBlacklist.some(p => p.test(win.title ?? ""))
       ));
-    
     const project = (rect: Rectangle, canvas: Rectangle): Rectangle => ({
       x: canvas.x + canvas.width * rect.x,
       y: canvas.y + canvas.height * rect.y,


### PR DESCRIPTION
This fixes Issue #422 (https://github.com/gTile/gTile/issues/422) by making sure that if only dynamic columns are available for colspec autotiling, the focused window is placed at index zero of the windows[] array.