### PR TITLE
Fix runtime error

### DIFF
--- a/src/ui/overlay/TextButton.ts
+++ b/src/ui/overlay/TextButton.ts
@@ -30,7 +30,7 @@ export default GObject.registerClass({
     ),
   }
 }, class extends St.Button {
-  #active!: boolean;
+  private _active!: boolean;
 
   /**
    * @returns A generic text button with the default style.
@@ -61,17 +61,17 @@ export default GObject.registerClass({
    * Whether the button state is considered active.
    */
   set active(b: boolean) {
-    this.#active = b;
-    this.#updateState();
+    this._active = b;
+    this._updateState();
     this.notify("active");
   }
 
   get active(): boolean {
-    return this.#active;
+    return this._active;
   }
 
-  #updateState() {
-    if (this.#active) {
+  private _updateState() {
+    if (this._active) {
       this.add_style_pseudo_class("activate");
     } else {
       this.remove_style_pseudo_class("activate");


### PR DESCRIPTION
For an unknown reason, runtime instances of the TextButton class are unable to access private fields/methods. Dispite them working as expected, this commit resorts by exposing all class fields/methods to the outside.

JS ERROR: TypeError: can't access private field or method: object is not the right class
  set active@file:///home/vsx/.local/share/gnome-shell/extensions/gTile@vibou/ui/overlay/TextButton.js:28:9