### PR TITLE
Fix status indicator conflict after screen lock/unlock cycle

### DIFF
--- a/src/core/App.ts
+++ b/src/core/App.ts
@@ -139,6 +139,12 @@ export default class App implements GarbageCollector {
     this.#gc.defer(() => this.#panelIcon.destroy());
 
     // --- show  UI ---
+    // Remove any stale indicator from a previous enable/disable cycle
+    // (e.g. after screen lock/unlock) to avoid "Extension point conflict"
+    const existingIndicator = Main.panel.statusArea[extension.uuid];
+    if (existingIndicator) {
+      existingIndicator.destroy();
+    }
     Main.panel.addToStatusArea(extension.uuid, this.#panelIcon);
 
     // --- event handlers ---


### PR DESCRIPTION
## Summary

Fixes the "Extension point conflict" error that causes the extension to fail to load after every screen lock/unlock or suspend/resume cycle.

## The problem

When the screen is locked and unlocked, GNOME Shell calls `disable()` then `enable()` on all extensions. The `disable()` method calls `this.#app.release()`, which triggers `GarbageCollection` to destroy the panel icon. On the next `enable()`, `App.run()` creates a new instance and calls `Main.panel.addToStatusArea(extension.uuid, ...)`.

However, `addToStatusArea()` throws:

```
Extension gTile@vibou: Error: Extension point conflict:
there is already a status indicator for role gTile@vibou
```

### Why this happens

The GNOME Shell panel internally tracks status indicators by their role name. During a rapid `disable()`/`enable()` cycle (as happens on screen lock/unlock), the panel's internal `statusArea` registry may still hold a reference to the old indicator role even after `destroy()` has been called. This is because `destroy()` is asynchronous in GObject — the actual cleanup happens in the next main loop iteration, but `enable()` is called synchronously right after `disable()`.

This causes the extension to **completely fail to load** after every lock/unlock, requiring a full session restart.

## Fix

In `src/core/App.ts`, before calling `addToStatusArea()`, check if a stale indicator already exists in `Main.panel.statusArea` and destroy it:

```ts
const existingIndicator = Main.panel.statusArea[extension.uuid];
if (existingIndicator) {
  existingIndicator.destroy();
}
Main.panel.addToStatusArea(extension.uuid, this.#panelIcon);
```

This is a well-known pattern used by many GNOME Shell extensions to handle this race condition.

## Note on `App.#instance` guard

The `App.run()` static method already checks for an existing instance and throws. However, the crash happens *before* that check is relevant: the previous instance was properly released by `disable()`, but the panel's `statusArea` still holds a stale reference. The fix addresses the panel-level conflict, not the App-level singleton.

## Environment

- GNOME Shell 46.0 (Ubuntu 24.04 noble, Wayland)
- Extension version 59

## Test plan

- [ ] Extension loads correctly after a fresh login
- [ ] Lock and unlock the screen — extension still active with icon in panel
- [ ] Suspend and resume — extension still works
- [ ] Repeat lock/unlock multiple times — no errors in `journalctl --user`