### PR TITLE
fix: Add GNOME 45-48 compatibility

### DIFF
--- a/dist/metadata.json
+++ b/dist/metadata.json
@@ -2,7 +2,7 @@
   "uuid": "gTile@vibou",
   "name": "gTile",
   "description": "Tile windows on a grid",
-  "shell-version": ["49", "50"],
+  "shell-version": ["45", "46", "47", "48", "49", "50"],
   "url": "https://github.com/gTile",
   "settings-schema": "org.gnome.shell.extensions.gtile",
   "version": 69

--- a/src/core/DesktopManager.ts
+++ b/src/core/DesktopManager.ts
@@ -175,8 +175,12 @@ export default class implements Publisher<DesktopEvent>, GarbageCollector {
    */
   moveToMonitor(target: Meta.Window, monitorIdx?: number) {
     monitorIdx = monitorIdx ?? (target.get_monitor() + 1) % this.monitors.length;
-    target.set_unmaximize_flags(Meta.MaximizeFlags.BOTH);
-    target.unmaximize();
+    // set_unmaximize_flags is only available in GNOME 49+
+    if (typeof target.set_unmaximize_flags === 'function') {
+      target.set_unmaximize_flags(Meta.MaximizeFlags.BOTH);
+    }
+    // @ts-ignore - unmaximize signature differs between GNOME versions
+    target.unmaximize(Meta.MaximizeFlags.BOTH);
     if (monitorIdx === target.get_monitor()) {
       return;
     }
@@ -521,8 +525,12 @@ export default class implements Publisher<DesktopEvent>, GarbageCollector {
   }
 
   #moveResize(target: Meta.Window, x: number, y: number, size?: FrameSize) {
-    target.set_unmaximize_flags(Meta.MaximizeFlags.BOTH);
-    target.unmaximize();
+    // set_unmaximize_flags is only available in GNOME 49+
+    if (typeof target.set_unmaximize_flags === 'function') {
+      target.set_unmaximize_flags(Meta.MaximizeFlags.BOTH);
+    }
+    // @ts-ignore - unmaximize signature differs between GNOME versions
+    target.unmaximize(Meta.MaximizeFlags.BOTH);
 
     // All internal calculations fictively operate as if the actual window frame
     // size would also incorporate the user-defined window spacing. Only when a


### PR DESCRIPTION
- Add runtime check for set_unmaximize_flags() which is only available in GNOME 49+
- Pass MaximizeFlags.BOTH parameter to unmaximize() for GNOME 46 compatibility
- Update metadata.json to support GNOME Shell versions 45-50

Fixes window resize/move functionality on GNOME 45-48 where set_unmaximize_flags is not available and unmaximize() requires a parameter.